### PR TITLE
Sort Ys and Final Fantasy music into categories

### DIFF
--- a/Community Jukebox/scripts/MusicList.lemon
+++ b/Community Jukebox/scripts/MusicList.lemon
@@ -16,18 +16,22 @@ constant array<string> CommunityJukebox_Music =
     //Touhou music
     "EasternMysticalTaleOfRomance",
 
-    //Misc and ungroupable music
-    "CaptainUnderpantsMusic",
-    "GrandpaThemeSong",
+    // Ys music
     "Tension",    
     "IceRidgeOfNoltia",
     "BurningFight",
-    "bandland",
-    "conclusion",
+
+    // Final Fantasy music
     "protecttheespers",
     "crazymotorcyclechase",
     "manwithmachinegun",
     "ff9battle",
+
+    //Misc and ungroupable music
+    "CaptainUnderpantsMusic",
+    "GrandpaThemeSong",
+    "bandland",
+    "conclusion",
     "ryualpha3",
     "vrtraining",
     "warproom",


### PR DESCRIPTION
For consistency with Sonic, Persona/SMT and Touhou, these particular track categories have been sorted into their own categories within MusicList.lemon

Might do the same for the other stuff I added but since there's only one song for those categories. I'm also considering adding a dedicated "meme" category located at the back of the array so that I don't have to hear about sexy grandads whenever I want to listen to Rayman music.